### PR TITLE
CKEditor #9: Adjust toolbar offset to account for admin bar. Basic styling for loading indicator.

### DIFF
--- a/css/ckeditor5.css
+++ b/css/ckeditor5.css
@@ -1,32 +1,43 @@
 /**
  * CSS needed when displaying a CKEditor instance.
  */
+
+/**
+ * Hide the powered-by label from the lower right corner.
+ */
 .ck-powered-by {
   display: none;
 }
 
+/**
+ * Set z-index of the sticky toolbar to be below the Backdrop admin bar.
+ */
+.ck.ck-sticky-panel .ck-sticky-panel__content_sticky {
+  z-index: 998 !important;
+}
+
 .ckeditor5-dialog-loading {
   position: absolute;
-  top: 0;
+  top: 6px;
+  left: 0;
   width: 100%;
   text-align: center;
 }
 
 .ckeditor5-dialog-loading-link {
-  border-radius: 0 0 5px 5px;
+  position: relative;
+  top: 0;
+  display: inline-block;
+  border-radius: 5px;
   border: 1px solid #B6B6B6;
   border-top: none;
   background: white;
   padding: 3px 10px;
-  box-shadow: 0 0 10px -3px #000;
-  display: inline-block;
+  box-shadow: 0 0 6px -3px #000;
   font-size: 14px;
-  position: relative;
-  top: 0;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
+}
+
+.ckeditor5-dialog-loading-link .ajax-throbber {
+  vertical-align: bottom;
 }


### PR DESCRIPTION
Fixes #9