### PR TITLE
CKEditor #13: Adjust default editor button order, fix link from being disabled.

### DIFF
--- a/ckeditor5.module
+++ b/ckeditor5.module
@@ -470,22 +470,6 @@ function ckeditor5_ckeditor5_plugins() {
     ),
   );
 
-  // See https://ckeditor.com/docs/ckeditor5/latest/features/undo-redo.html
-  $plugins['undo.Undo'] = array(
-    'buttons' => array(
-      'undo' => array(
-        'label' => t('Undo'),
-        'image' => $image_prefix . '/undo.svg',
-        'image_rtl' => $image_prefix . '/undo-rtl.svg',
-      ),
-      'redo' => array(
-        'label' => t('Redo'),
-        'image' => $image_prefix . '/redo.svg',
-        'image_rtl' => $image_prefix . '/redo-rtl.svg',
-      ),
-    ),
-  );
-
   // Plugin that converts CKEditor preferred tags to Backdrop preferred tags,
   // such as converting <s> to <del> or <i> to <em>.
   $plugins['backdropBasicStyles.BackdropBasicStyles'] = array(
@@ -544,7 +528,9 @@ function ckeditor5_ckeditor5_plugins() {
       'link' => array(
         'label' => t('Link'),
         'image' => $image_prefix . '/link.svg',
-        'required_html' => array('<a href target class id title rel data-file-id>'),
+        // @todo: The id attribute is being flagged as disallowed by core's
+        // blocking of on* attributes. It should be included here.
+        'required_html' => array('<a href target class title rel data-file-id>'),
         'plugin_dependencies' => array('backdropLink.BackdropLink'),
       ),
     ),
@@ -572,6 +558,22 @@ function ckeditor5_ckeditor5_plugins() {
 
   $plugins['backdropLink.BackdropLink'] = array(
     'library' => array('ckeditor5', 'backdrop.ckeditor5.backdrop-link'),
+  );
+
+  // See https://ckeditor.com/docs/ckeditor5/latest/features/undo-redo.html
+  $plugins['undo.Undo'] = array(
+    'buttons' => array(
+      'undo' => array(
+        'label' => t('Undo'),
+        'image' => $image_prefix . '/undo.svg',
+        'image_rtl' => $image_prefix . '/undo-rtl.svg',
+      ),
+      'redo' => array(
+        'label' => t('Redo'),
+        'image' => $image_prefix . '/redo.svg',
+        'image_rtl' => $image_prefix . '/redo-rtl.svg',
+      ),
+    ),
   );
 
   return $plugins;

--- a/js/ckeditor5.admin.js
+++ b/js/ckeditor5.admin.js
@@ -9,7 +9,7 @@ Backdrop.behaviors.ckeditor5Admin = {
     // Set up toolbar drag-and-drop interface and add/remove allowed HTML tags.
     $context.find('.ckeditor5-toolbar-configuration').once('ckeditor5-toolbar', function() {
       var $wrapper = $(this);
-      var $textareaWrapper = $(this).find('.form-item-editor-settings-toolbar').hide();
+      var $textareaWrapper = $wrapper.find('.form-item-editor-settings-toolbar').hide();
       var $textarea = $textareaWrapper.find('textarea');
       var $toolbarAdmin = $(settings.ckeditor5.toolbarAdmin);
       var sortableSettings = {


### PR DESCRIPTION
Fixes https://github.com/quicksketch/ckeditor5/issues/13.